### PR TITLE
fix(sponsors): policy link 404s (blob/main -> blob/HEAD)

### DIFF
--- a/src/components/astro/SponsorsContent.astro
+++ b/src/components/astro/SponsorsContent.astro
@@ -28,7 +28,7 @@ const sponsorGroups = WEB_TIERS.map((tier) => ({
   })),
 })).filter((g) => g.entries.length > 0);
 
-const POLICY_URL = 'https://github.com/yusufkaraaslan/Skill_Seekers/blob/main/SPONSORSHIP.md';
+const POLICY_URL = 'https://github.com/yusufkaraaslan/Skill_Seekers/blob/HEAD/SPONSORSHIP.md';
 const mailtoHref = 'mailto:' + data.contact;
 
 const tierLabel: Record<string, string> = {

--- a/src/utils/sponsors.ts
+++ b/src/utils/sponsors.ts
@@ -13,7 +13,7 @@
 import fallback from '../data/sponsors.json';
 
 const SPONSORS_JSON_URL =
-  'https://raw.githubusercontent.com/yusufkaraaslan/Skill_Seekers/development/sponsors.json';
+  'https://raw.githubusercontent.com/yusufkaraaslan/Skill_Seekers/HEAD/sponsors.json';
 
 export interface Sponsor {
   name: string;


### PR DESCRIPTION
The **Full policy** button on /sponsors led to an empty page.

`SPONSORSHIP.md` lives on `development` (the repo's default branch) and hasn't reached `main`, so `blob/main/SPONSORSHIP.md` returns **404**.

Both cross-repo URLs now use the branch-agnostic `HEAD` ref, which resolves to the default branch and will keep working once the file also lands on `main`:

| URL | Before | After |
|---|---|---|
| Policy link | `blob/main/...` → **404** | `blob/HEAD/...` → **200** ✅ |
| Sponsor data | `raw/development/...` | `raw/HEAD/...` → **200** ✅ |

Verified with a real `astro build`: the rendered link points at HEAD, and the sponsor-data fetch now succeeds live instead of falling back to the committed copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)