### PR TITLE
docs(sponsors): align tier wording with SPONSORSHIP.md

### DIFF
--- a/src/components/astro/SponsorsContent.astro
+++ b/src/components/astro/SponsorsContent.astro
@@ -47,28 +47,28 @@ const tiers = [
   {
     name: isZh ? '青铜' : 'Bronze',
     price: '$50',
-    perk: isZh ? 'README 底部赞助网格中的小徽标' : 'Small logo in the README sponsor grid',
+    perk: isZh ? 'README 赞助区中的小徽标' : 'Small logo in the README sponsor section',
   },
   {
     name: isZh ? '白银' : 'Silver',
     price: '$150',
     perk: isZh
-      ? 'README 赞助网格中的中等徽标 + 本站赞助页展示'
-      : 'Medium logo in the README grid + logo on this page',
+      ? 'README 赞助区中的中等徽标，位于青铜之上 + 本站赞助页展示'
+      : 'Medium logo in the README sponsor section, above Bronze + logo on this page',
   },
   {
     name: isZh ? '黄金' : 'Gold',
     price: '$400',
     perk: isZh
-      ? 'README 赞助区顶部的大徽标 + 网站展示 + 发布说明提及'
-      : 'Large logo near the top of the README + website placement + mention in release notes',
+      ? 'README 赞助区中的大徽标，位于白银与青铜之上 + 网站展示 + 发布说明提及'
+      : 'Large logo listed above Silver and Bronze in the README sponsor section + website placement + mention in release notes',
   },
   {
     name: isZh ? '白金' : 'Platinum',
     price: '$1,000',
     perk: isZh
-      ? '黄金全部权益 + README 中的简短「赞助」说明 + 优先问题处理'
-      : 'Everything in Gold + a short "Sponsored" blurb in the README + priority issue triage',
+      ? '黄金全部权益，且排列在最前 + README 中的简短「赞助」说明 + 优先问题处理'
+      : 'Everything in Gold, listed first + a short "Sponsored" blurb in the README + priority issue triage',
   },
 ];
 


### PR DESCRIPTION
[Skill_Seekers#448](https://github.com/yusufkaraaslan/Skill_Seekers/pull/448) consolidated the README into one sponsor section, so tier perks were reworded there from *top vs bottom placement* to **order and size**. The website still described the old layout — meaning the two pages disagreed about what a sponsor is buying.

| Tier | Before | After |
|---|---|---|
| Bronze | "README sponsor **grid**" | "README sponsor **section**" |
| Silver | "README grid" | "sponsor section, **above Bronze**" |
| Gold | "**near the top** of the README" | "**listed above Silver and Bronze**" |
| Platinum | "Everything in Gold" | "Everything in Gold, **listed first**" |

Both EN and ZH updated. Verified with a real `astro build` — wording renders correctly in both languages, and RapidProxy now appears since upstream `sponsors.json` carries it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)