### PR TITLE
fix: Fix npm audit high severity vulnerabilities in build dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@astrojs/react": "^4.4.2",
     "@astrojs/rss": "^4.0.15",
     "@astrojs/sitemap": "^3.7.0",
-    "@astrojs/vercel": "^9.0.2",
+    "@astrojs/vercel": "^9.0.3",
     "@sentry/astro": "^10.34.0",
     "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.1.18",


### PR DESCRIPTION
Closes #17

Patch generated by `qwen3.6-35b-a3b via local API`.